### PR TITLE
fix: verify CrowdSec TLS certificates by default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2023-2025 CrowdSec
+   Copyright (c) 2023-2026 CrowdSec
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: CrowdSec
-Copyright (c) 2023-2025 CrowdSec
+Copyright (c) 2023-2026 CrowdSec

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # CrowdSec
 
-Publisher: CrowdSec \
-Connector Version: 1.0.2 \
-Product Vendor: CrowdSec \
-Product Name: CrowdSec \
+Publisher: CrowdSec <br>
+Connector Version: 1.0.2 <br>
+Product Vendor: CrowdSec <br>
+Product Name: CrowdSec <br>
 Minimum Product Version: 5.5.0
 
 Splunk SOAR App which integrates with CrowdSec. It provides the ability to lookup an IP address in CrowdSec's threat intelligence feed
@@ -14,18 +14,19 @@ This table lists the configuration variables required to operate CrowdSec. These
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------
+**verify_server_cert** | optional | boolean | Verify server certificate |
 **CROWDSEC_CTI_API_KEY** | required | string | API key for CrowdSec CTI API |
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
 [lookup ip](#action-lookup-ip) - Check for the presence of an IP in a threat intelligence feed
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -40,7 +41,7 @@ No Output
 
 Check for the presence of an IP in a threat intelligence feed
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -95,7 +96,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2023-2025 CrowdSec
+# Copyright (c) 2023-2026 CrowdSec
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/crowdsec.json
+++ b/crowdsec.json
@@ -10,7 +10,7 @@
     "python_version": "3.9, 3.13",
     "product_version_regex": ".*",
     "publisher": "CrowdSec",
-    "license": "Copyright (c) 2023-2025 CrowdSec",
+    "license": "Copyright (c) 2023-2026 CrowdSec",
     "app_version": "1.0.2",
     "utctime_updated": "2025-04-28T19:19:40.348186Z",
     "package_name": "phantom_crowdsec",
@@ -297,6 +297,14 @@
         }
     ],
     "pip39_dependencies": {
+        "wheel": [
+            {
+                "module": "chardet",
+                "input_file": "wheels/shared/chardet-3.0.4-py2.py3-none-any.whl"
+            }
+        ]
+    },
+    "pip313_dependencies": {
         "wheel": [
             {
                 "module": "chardet",

--- a/crowdsec.json
+++ b/crowdsec.json
@@ -19,6 +19,13 @@
     "fips_compliant": false,
     "app_wizard_version": "1.0.0",
     "configuration": {
+        "verify_server_cert": {
+            "description": "Verify server certificate",
+            "data_type": "boolean",
+            "required": false,
+            "default": true,
+            "order": 1
+        },
         "CROWDSEC_CTI_API_KEY": {
             "description": "API key for CrowdSec CTI API",
             "data_type": "string",

--- a/crowdsec.json
+++ b/crowdsec.json
@@ -7,7 +7,7 @@
     "logo": "logo_crowdsec.svg",
     "logo_dark": "logo_crowdsec_dark.svg",
     "product_name": "CrowdSec",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "product_version_regex": ".*",
     "publisher": "CrowdSec",
     "license": "Copyright (c) 2023-2025 CrowdSec",

--- a/crowdsec_connector.py
+++ b/crowdsec_connector.py
@@ -155,7 +155,7 @@ class CrowdsecConnector(BaseConnector):
             r = request_func(
                 url,
                 # auth=(username, password),  # basic authentication
-                verify=config.get("verify_server_cert", False),
+                verify=config.get("verify_server_cert", True),
                 timeout=self._timeout,
                 **kwargs,
             )

--- a/crowdsec_connector.py
+++ b/crowdsec_connector.py
@@ -1,6 +1,6 @@
 # File: crowdsec_connector.py
 #
-# Copyright (c) 2023-2025 CrowdSec
+# Copyright (c) 2023-2026 CrowdSec
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/crowdsec_consts.py
+++ b/crowdsec_consts.py
@@ -1,6 +1,6 @@
 # File: crowdsec_consts.py
 #
-# Copyright (c) 2023-2025 CrowdSec
+# Copyright (c) 2023-2026 CrowdSec
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/crowdsec_lookup_ip.html
+++ b/crowdsec_lookup_ip.html
@@ -11,7 +11,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!-- File: crowdsec_lookup_ip.html
-  Copyright (c) 2023-2025 CrowdSec
+  Copyright (c) 2023-2026 CrowdSec
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crowdsec_view.py
+++ b/crowdsec_view.py
@@ -1,6 +1,6 @@
 # File: crowdsec_view.py
 #
-# Copyright (c) 2023-2025 CrowdSec
+# Copyright (c) 2023-2026 CrowdSec
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/readme.html
+++ b/readme.html
@@ -1,5 +1,5 @@
 <!--File: readme.html
-Copyright (c) 2023-2025 CrowdSec
+Copyright (c) 2023-2026 CrowdSec
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* - Verify TLS certificates by default for CrowdSec API requests.
+* Verify TLS certificates by default for CrowdSec API requests.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+- Verify TLS certificates by default for CrowdSec API requests.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-- Verify TLS certificates by default for CrowdSec API requests.
+* - Verify TLS certificates by default for CrowdSec API requests.


### PR DESCRIPTION
## Summary

- add a server-certificate verification asset setting that defaults to enabled
- default runtime TLS verification to enabled for existing assets without the setting
- refresh generated connector metadata and dependency manifests

## Tracking

- PAPP-38143
- Parent epic: ESPM-5228
- PSAAS-30974

## Validation

- local compile: passed
- local pre-commit and static tests: passed
- hosted pre-commit and compile: pending

Created by Codex with AI assistance.

## Tracking

- PAPP: PAPP-38143
- PSAAS: PSAAS-30974
- Written by Codex.